### PR TITLE
Adding reshape_bondorder_lists_cutoff

### DIFF
--- a/package/KudoCop/SimulationDat.py
+++ b/package/KudoCop/SimulationDat.py
@@ -366,6 +366,22 @@ class SimulationDat(
         return density
     
     def reshape_bondorder_list_cutoff(self, cut_off):
+<<<<<<< Updated upstream
+=======
+        """
+        dumpbondから作成したbondorder_list内の、bond orderの和がcut_off未満の行を削除する関数
+
+        Parameters
+        ----------
+        cut_off : float
+            cut_offの単位はbond order
+            ある原子とある原子のbond orderの和がcut_off未満のときの結合を除外する
+        judge_cutoff : list
+            ある原子([atom_idx])に着目した場合、bondorder_list[atom_idx]の中で
+            bond orderの和がcut_off未満である結合の、bondorder_list[atom_idx]内での順番を保存する配列。
+
+        """
+>>>>>>> Stashed changes
         if cut_off is None:
             print('cut_off is not defined')
             sys.exit(-1)
@@ -373,10 +389,19 @@ class SimulationDat(
             print('bondorder_list is not defined')
             print('Import dumppos first')
             sys.exit(-1)
+<<<<<<< Updated upstream
         for id in range(len(self.atoms)):
             judge_cutoff = []
             for connect_id in range(len(self.bondorder_list[id])):
                 if self.bondorder_list[id][connect_id][-1] < cut_off:
                     judge_cutoff.append(connect_id)
             self.bondorder_list[id] = np.delete(self.bondorder_list[id], judge_cutoff, 0)
+=======
+        for atom_idx in range(len(self.atoms)):
+            judge_cutoff = []
+            for connected_atom_row in range(len(self.bondorder_list[atom_idx])):
+                if self.bondorder_list[atom_idx][connected_atom_row][-1] < cut_off:
+                    judge_cutoff.append(connected_atom_row)
+            self.bondorder_list[atom_idx] = np.delete(self.bondorder_list[atom_idx], judge_cutoff, 0)
+>>>>>>> Stashed changes
         return self.bondorder_list

--- a/package/KudoCop/SimulationDat.py
+++ b/package/KudoCop/SimulationDat.py
@@ -364,3 +364,19 @@ class SimulationDat(
         # セル内の密度(g/cm^3)
         density = all_weight / volume
         return density
+    
+    def reshape_bondorder_list_cutoff(self, cut_off):
+        if cut_off is None:
+            print('cut_off is not defined')
+            sys.exit(-1)
+        if self.bondorder_list is None:
+            print('bondorder_list is not defined')
+            print('Import dumppos first')
+            sys.exit(-1)
+        for id in range(len(self.atoms)):
+            judge_cutoff = []
+            for connect_id in range(len(self.bondorder_list[id])):
+                if self.bondorder_list[id][connect_id][-1] < cut_off:
+                    judge_cutoff.append(connect_id)
+            self.bondorder_list[id] = np.delete(self.bondorder_list[id], judge_cutoff, 0)
+        return self.bondorder_list

--- a/package/KudoCop/SimulationDats.py
+++ b/package/KudoCop/SimulationDats.py
@@ -191,6 +191,22 @@ class SimulationDats(
                 self.atoms[step_idx].reset_index(drop=True, inplace=True)
 
     def reshape_bondorder_lists_cutoff(self, cut_off):
+<<<<<<< Updated upstream
+=======
+        """
+        dumpbondsから作成したbondorder_lists内の、bond orderの和がcut_off未満の行を削除する関数
+        
+        Parameters
+        ----------
+        cut_off : float
+            cut_offの単位はbond order
+            ある原子とある原子のbond orderの和がcut_off未満のときの結合を除外する
+        judge_cutoff : list
+            ある原子([atom_idx])に着目した場合、bondorder_lists[atom_idx]の中で
+            bond orderの和がcut_off未満である結合の、bondorder_lists[atom_idx]内での順番を保存する配列。
+
+        """
+>>>>>>> Stashed changes
         if cut_off is None:
             print('cut_off is not defined')
             sys.exit(-1)
@@ -199,10 +215,19 @@ class SimulationDats(
             print('Import dumppos first')
             sys.exit(-1)
         for step_idx in range(len(self.step_nums)):
+<<<<<<< Updated upstream
             for id in range(len(self.atoms)):
                 judge_cutoff = []
                 for connect_id in range(len(self.bondorder_lists[step_idx][id])):
                     if self.bondorder_lists[step_idx][id][connect_id][-1] < cut_off:
                         judge_cutoff.append(connect_id)
                 self.bondorder_lists[step_idx][id] = np.delete(self.bondorder_lists[step_idx][id], judge_cutoff, 0)
+=======
+            for atom_idx in range(len(self.atoms[0])):
+                judge_cutoff = []
+                for connected_atom_row in range(len(self.bondorder_lists[step_idx][atom_idx])):
+                    if self.bondorder_lists[step_idx][atom_idx][connected_atom_row][-1] < cut_off:
+                        judge_cutoff.append(connected_atom_row)
+                self.bondorder_lists[step_idx][atom_idx] = np.delete(self.bondorder_lists[step_idx][atom_idx], judge_cutoff, 0)
+>>>>>>> Stashed changes
         return self.bondorder_lists

--- a/package/KudoCop/SimulationDats.py
+++ b/package/KudoCop/SimulationDats.py
@@ -190,4 +190,19 @@ class SimulationDats(
             if reindex:
                 self.atoms[step_idx].reset_index(drop=True, inplace=True)
 
-    
+    def reshape_bondorder_lists_cutoff(self, cut_off):
+        if cut_off is None:
+            print('cut_off is not defined')
+            sys.exit(-1)
+        if self.bondorder_lists is None:
+            print('bondorder_list is not defined')
+            print('Import dumppos first')
+            sys.exit(-1)
+        for step_idx in range(len(self.step_nums)):
+            for id in range(len(self.atoms)):
+                judge_cutoff = []
+                for connect_id in range(len(self.bondorder_lists[step_idx][id])):
+                    if self.bondorder_lists[step_idx][id][connect_id][-1] < cut_off:
+                        judge_cutoff.append(connect_id)
+                self.bondorder_lists[step_idx][id] = np.delete(self.bondorder_lists[step_idx][id], judge_cutoff, 0)
+        return self.bondorder_lists


### PR DESCRIPTION
Simulationdat.pyに、bondorder_list中のcut_off未満の行を削除する関数(reshape_bondorder_list_cutoff)を追加。
Simulationdats.pyに、bondorder_lists中のcut_off未満の行を削除する関数(reshape_bondorder_lists_cutoff)を追加。